### PR TITLE
read_at_*

### DIFF
--- a/include/big_mpi_compat.h
+++ b/include/big_mpi_compat.h
@@ -314,6 +314,68 @@ namespace BigMPICompat
     return MPI_SUCCESS;
   }
 
+
+
+  inline int
+  MPI_File_read_at_c(MPI_File     fh,
+                      MPI_Offset   offset,
+                      void * buf,
+                      MPI_Count    count,
+                      MPI_Datatype datatype,
+                      MPI_Status * status)
+  {
+    if (count <= BigMPICompat::mpi_max_count)
+      return MPI_File_read_at(fh, offset, buf, count, datatype, status);
+
+    MPI_Datatype bigtype;
+    int          ierr;
+    ierr = MPI_Type_contiguous_c(count, datatype, &bigtype);
+    if (ierr != MPI_SUCCESS)
+      return ierr;
+    ierr = MPI_Type_commit(&bigtype);
+    if (ierr != MPI_SUCCESS)
+      return ierr;
+
+    ierr = MPI_File_read_at(fh, offset, buf, 1, bigtype, status);
+    if (ierr != MPI_SUCCESS)
+      return ierr;
+
+    ierr = MPI_Type_free(&bigtype);
+    if (ierr != MPI_SUCCESS)
+      return ierr;
+    return MPI_SUCCESS;
+  }
+
+  inline int
+  MPI_File_read_at_all_c(MPI_File     fh,
+                      MPI_Offset   offset,
+                      void * buf,
+                      MPI_Count    count,
+                      MPI_Datatype datatype,
+                      MPI_Status * status)
+  {
+    if (count <= BigMPICompat::mpi_max_count)
+      return MPI_File_read_at_all(fh, offset, buf, count, datatype, status);
+
+    MPI_Datatype bigtype;
+    int          ierr;
+    ierr = MPI_Type_contiguous_c(count, datatype, &bigtype);
+    if (ierr != MPI_SUCCESS)
+      return ierr;
+    ierr = MPI_Type_commit(&bigtype);
+    if (ierr != MPI_SUCCESS)
+      return ierr;
+
+    ierr = MPI_File_read_at_all(fh, offset, buf, 1, bigtype, status);
+    if (ierr != MPI_SUCCESS)
+      return ierr;
+
+    ierr = MPI_Type_free(&bigtype);
+    if (ierr != MPI_SUCCESS)
+      return ierr;
+    return MPI_SUCCESS;
+  }
+
 } // namespace BigMPICompat
 
 #endif

--- a/tests/io.cxx
+++ b/tests/io.cxx
@@ -23,7 +23,7 @@ test_write(const std::uint64_t n_bytes, const std::string &command)
   ierr =
     MPI_File_open(MPI_COMM_WORLD,
                   "io.data",
-                  MPI_MODE_CREATE | MPI_MODE_DELETE_ON_CLOSE | MPI_MODE_WRONLY,
+                  MPI_MODE_CREATE | MPI_MODE_WRONLY,
                   info,
                   &fh);
   CheckMPIFatal(ierr);
@@ -71,14 +71,69 @@ test_write(const std::uint64_t n_bytes, const std::string &command)
   CheckMPIFatal(ierr);
 }
 
+
+void
+test_read(const std::uint64_t n_bytes, const std::string &command)
+{
+  int ierr;
+  int myid, ranks;
+  MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+  MPI_Comm_size(MPI_COMM_WORLD, &ranks);
+  assert(ranks == 2);
+
+  std::uint64_t offset = myid * n_bytes;
+
+  MPI_File fh;
+  MPI_Info info;
+  ierr = MPI_Info_create(&info);
+  CheckMPIFatal(ierr);
+
+  ierr =
+    MPI_File_open(MPI_COMM_WORLD,
+                  "io.data",
+                  MPI_MODE_DELETE_ON_CLOSE | MPI_MODE_RDONLY,
+                  info,
+                  &fh);
+  CheckMPIFatal(ierr);
+
+  std::vector<char> buffer(n_bytes, '?');
+
+  if (command == "read_at")
+    ierr = BigMPICompat::MPI_File_read_at_c(
+      fh, offset, buffer.data(), buffer.size(), MPI_CHAR, MPI_STATUS_IGNORE);
+  else if (command == "read_at_all")
+    ierr = BigMPICompat::MPI_File_read_at_all_c(
+      fh, offset, buffer.data(), buffer.size(), MPI_CHAR, MPI_STATUS_IGNORE);
+  else
+    MPI_Abort(MPI_COMM_WORLD, 1);
+
+  CheckMPIFatal(ierr);
+
+  // ierr = MPI_File_sync(fh);
+  // CheckMPIFatal(ierr);
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  ierr = MPI_File_close(&fh);
+  CheckMPIFatal(ierr);
+}
+
 int
 main(int argc, char *argv[])
 {
   MPI_Init(&argc, &argv);
 
   test_write((1ULL << 32) + 2, "write_at");
+  std::cout << "in script write at done. " << std::endl;
+
+  test_read((1ULL << 32) + 2,"read_at"); 
+  std::cout << "in script read at done. " << std::endl;
+
   test_write((1ULL << 32) + 2, "write_at_all");
-  test_write((1ULL << 32) + 2, "write_ordered");
+  std::cout << "in script write at all done. " << std::endl;
+
+  test_read((1ULL << 32) + 2,"read_at_all"); 
+  std::cout << "in script read at all done. " << std::endl;
 
   MPI_Finalize();
   return 0;


### PR DESCRIPTION
I added the read_at_c and read_at_all_c based on your implementation, there're only a few minor changes in my implementation.

I followed the idea we discussed on testing read functions: I remove the MPI_MODE_DELETE_ON_CLOSE in original test so the that file will be kept for testing. All tests are passed by the end.

While I'm testing my work, I removed the tests/sendrecv.cxx in CMakeLists.txt because I sometimes get the "out of memory" error (killed a process), but I didn't commit that change, I don't think it's necessary. 
